### PR TITLE
Ch. 3 potential typo correction

### DIFF
--- a/src/content/chapters/3-how-to-run-a-program.mdx
+++ b/src/content/chapters/3-how-to-run-a-program.mdx
@@ -121,7 +121,7 @@ The first major job of `do_execveat_common` is setting up a struct called `linux
 
 - Data structures like `mm_struct` and `vm_area_struct` are defined to prepare virtual memory management for the new program.
 - `argc` and `envc` are calculated and stored to be passed to the program.
-- `filename` and `interp` store the filename of the program and its interpreter, respectively. These start out equal to each other, but can change in some cases: one such case occurs when the binary being *executed* is different from the program name is when running interpreted programs like Python scripts with a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)). In this example, `filename` points to the Python file but the `interp` is the Python interpreter's path.
+- `filename` and `interp` store the filename of the program and its interpreter, respectively. These start out equal to each other, but can change in some cases: one such case occurs when the binary being *executed* is different from the program name, or when running interpreted programs like Python scripts with a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)). In this example, `filename` points to the Python file but the `interp` is the Python interpreter's path.
 - `buf` is an array filled with the first 256 bytes of the file to be executed. It's used to detect the format of the file and load script shebangs.
 
 (TIL: binprm stands for **bin**ary **pr**og**r**a**m**.)


### PR DESCRIPTION
> one such case occurs when the binary being executed is different from the program name is when running interpreted programs like Python scripts with a shebang.

I guess this was meant to be two separate things, 1. "when the binary ..." and 2. "when running interpreted programs ...". Hence the correction.